### PR TITLE
config(env): 更新生产环境和测试环境的服务器配置

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,6 @@
 # 生产环境
 VITE_APP_ENV = production
 # 生产环境下的接口基础地址
-VITE_APP_BASE_API = http://111.231.13.141
+VITE_APP_BASE_API = http://云服务器外网ip
 # 生产环境下的页面标题
 VITE_APP_TITLE = 稚能安居后台管理系统

--- a/.env.staging
+++ b/.env.staging
@@ -1,6 +1,6 @@
 # 测试环境
 VITE_APP_ENV = staging
 # 测试环境下的接口基础地址
-VITE_APP_BASE_API = http://111.231.13.141
+VITE_APP_BASE_API = http://云服务器外网ip
 # 测试环境下的页面标题
 VITE_APP_TITLE = 稚能安居后台管理系统

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,10 +36,10 @@ export default defineConfig({
     proxy: {
       '/dev-api': {
         // 目前服务器地址
-        target: 'http://111.231.13.141:10030',
+        target: 'http://云服务器外网ip:80',
         changeOrigin: true, // 改变请求头的origin源，到达目标服务器的值target的值，而不是前端的请求路径
 
-        // 路径重写，如果不加rewrite，今后目标服务器收到的完整地址就是 http://47.108.58.48/dev-api/xxx,
+        // 路径重写，如果不加rewrite，今后目标服务器收到的完整地址就是 http://127.0.0.1/dev-api/xxx,
         // 由于目标目标服务器真实路径 没有 /dev-api，因此需要把这块给它去掉，这里用一个字符串 replace 方法，替换成空字符串即可
         rewrite: (path) => path.replace(/^\/dev-api/, '')
       }


### PR DESCRIPTION
- 将 .env.production 中的 VITE_APP_BASE_API 地址从固定IP更新为云服务器外网IP
- 将 .env.staging 中的 VITE_APP_BASE_API 地址从固定IP更新为云服务器外网IP
- 修改 vite.config.js 中代理目标地址从 111.231.13.141:10030 改为云服务器外网IP:80
- 更新代理配置中的注释说明，将目标服务器地址描述改为本地回环地址示例