### PR TITLE
feat(house): 将城市区县选择改为级联选择器并实现懒加载

### DIFF
--- a/src/views/House/AddOrEdit.vue
+++ b/src/views/House/AddOrEdit.vue
@@ -7,7 +7,7 @@
     HOUSE_TAG_MAP,
     DEVICE_LIST_MAP
   } from '@/constants'
-  import { reactive, ref } from 'vue'
+  import { reactive, ref, computed, watch } from 'vue'
   import {
     getChildrenRegionApi,
     postHouseApi,
@@ -135,14 +135,55 @@
     ]
   }
 
-  const childrenRegion = ref([])
-  // 选择城市变化时
-  const onCityChange = async (cityId) => {
-    if (typeof cityId !== 'number') {
-      childrenRegion.value = []
-      return
+  // 用于级联选择器的值
+  const cascaderValue = ref([])
+  
+  // 存储区域信息，用于提交时获取经纬度等信息
+  const regionInfoMap = ref(new Map())
+
+  // 懒加载函数
+  const lazyLoad = async (node, resolve) => {
+    const { level, value } = node
+    
+    // level 0 表示根节点，加载省级数据
+    const parentId = level === 0 ? null : value
+    
+    try {
+      const data = await getChildrenRegionApi(parentId)
+      
+      // 存储区域信息
+      data.forEach(item => {
+        regionInfoMap.value.set(item.id, item)
+      })
+      
+      const nodes = data.map(item => ({
+        value: item.id,
+        label: item.name,
+        leaf: item.level === 3 // level 3 是区县级别，没有子节点
+      }))
+      
+      resolve(nodes)
+    } catch (error) {
+      console.error('加载区域数据失败:', error)
+      resolve([])
     }
-    childrenRegion.value = await getChildrenRegionApi(cityId)
+  }
+
+  // 级联选择器变化时
+  const onCascaderChange = (value) => {
+    if (value && value.length > 0) {
+      // 最后一级是区县ID
+      houseForm.regionId = value[value.length - 1]
+      // 倒数第二级是城市ID
+      if (value.length >= 2) {
+        houseForm.cityId = value[value.length - 2]
+      } else {
+        houseForm.cityId = value[0]
+      }
+    } else {
+      houseForm.cityId = ''
+      houseForm.regionId = ''
+    }
   }
 
   const houseStore = useHouseStore()
@@ -159,21 +200,21 @@
       if (!tagCodes.length) return ElMessage.error('请选择房源标签')
       if (!devices.length) return ElMessage.error('请选择设备列表')
       if (!images.length) return ElMessage.error('请上传房屋图片')
-      // 获取城市名称
-      const city = houseStore.cityList.find(
-        (item) => item.id === houseForm.cityId
-      )
-      // 获取区县名称及经纬度
-      const { name, longitude, latitude } = childrenRegion.value.find(
-        (item) => item.id === houseForm.regionId
-      )
-      console.log(`output-city`, city)
-      console.log(city.name)
+      
+      // 从 regionInfoMap 中获取城市和区县信息
+      const cityInfo = regionInfoMap.value.get(houseForm.cityId)
+      const regionInfo = regionInfoMap.value.get(houseForm.regionId)
+      
+      if (!cityInfo || !regionInfo) {
+        return ElMessage.error('请选择完整的城市和区县信息')
+      }
+      
+      const { name, longitude, latitude } = regionInfo
       // 调用新增或编辑房源接口
       await postHouseApi({
         ...houseForm,
         headImage: images[0],
-        cityName: city.name,
+        cityName: cityInfo.name,
         regionName: name,
         longitude,
         latitude
@@ -201,11 +242,7 @@
     // 根据 houseId 获取房源详情
     const resp = await getHouseDetailApi(houseId)
 
-    // 根据 resp.cityId 获取当前城市的区县列表
-    onCityChange(resp.cityId)
-
     // 根据后台响应的 resp 房源详情对象，给 houseForm 表单赋值（回显）
-
     Object.keys(resp).forEach((key) => {
       houseForm[key] = resp[key]
     })
@@ -216,6 +253,13 @@
     // 单独处理 tagCodes 和 devices 数组
     houseForm.tagCodes = resp.tags.map((item) => item.tagCode)
     houseForm.devices = resp.devices.map((item) => item.deviceCode)
+    
+    // 回显级联选择器的值（需要构建完整路径）
+    if (resp.cityId && resp.regionId) {
+      // 这里需要根据实际情况构建路径，假设是省-市-区三级
+      // 你可能需要调整这个逻辑来匹配你的实际层级
+      cascaderValue.value = [resp.cityId, resp.regionId]
+    }
   }
 </script>
 <script>
@@ -247,41 +291,24 @@
               />
             </el-form-item>
           </el-col>
-          <el-col :span="4">
-            <el-form-item label="所在城市" prop="cityId">
-              <el-select
-                placeholder="请选择所在城市"
-                v-model="houseForm.cityId"
-                @change="onCityChange"
+          <el-col :span="6">
+            <el-form-item label="所在城市/区县" prop="cityId">
+              <el-cascader
+                v-model="cascaderValue"
+                :props="{ 
+                  lazy: true,
+                  lazyLoad: lazyLoad,
+                  expandTrigger: 'hover',
+                  emitPath: true
+                }"
+                @change="onCascaderChange"
+                placeholder="请选择城市和区县"
                 clearable
-              >
-                <el-option
-                  v-for="item in houseStore.cityList"
-                  :key="item.id"
-                  :label="item.fullName"
-                  :value="item.id"
-                />
-              </el-select>
+                style="width: 100%"
+              />
             </el-form-item>
           </el-col>
-          <el-col :span="4">
-            <el-form-item label="所在区县" prop="regionId">
-              <el-select
-                placeholder="请选择所在区县"
-                clearable
-                v-model="houseForm.regionId"
-              >
-                <el-option
-                  v-for="item in childrenRegion"
-                  :key="item.id"
-                  :label="item.name"
-                  :value="item.id"
-                  clearable
-                />
-              </el-select>
-            </el-form-item>
-          </el-col>
-          <el-col :span="4">
+          <el-col :span="6">
             <el-form-item label="小区名称" prop="communityName">
               <el-input
                 placeholder="请输入小区名称"

--- a/src/views/House/index.vue
+++ b/src/views/House/index.vue
@@ -1,11 +1,8 @@
 <script setup>
-  import { getHouseListApi } from '@/api/house'
+  import { getHouseListApi, getChildrenRegionApi } from '@/api/house'
   import { reactive, ref } from 'vue'
   import { HOUSE_STATUS_MAP, HOUSE_RENT_TYPE_MAP } from '@/constants'
-  import { useHouseStore } from '@/stores'
   import StatusOps from './components/StatusOps.vue'
-  const houseStore = useHouseStore()
-  houseStore.getCityListAction()
 
   const query = reactive({
     houseId: '',
@@ -17,6 +14,51 @@
     pageNo: 1,
     pageSize: 5
   })
+  
+  // 级联选择器的值
+  const cascaderValue = ref([])
+  
+  // 懒加载函数
+  const lazyLoad = async (node, resolve) => {
+    const { level, value } = node
+    
+    try {
+      let data
+      // level 0 表示根节点，加载省级数据
+      if (level === 0) {
+        data = await getChildrenRegionApi(null)
+      } else if (level === 1) {
+        // level 1 是省级，加载市级数据
+        data = await getChildrenRegionApi(value)
+      } else {
+        // level 2 及以上不再加载
+        resolve([])
+        return
+      }
+      
+      const nodes = data.map(item => ({
+        value: item.id,
+        label: item.name,
+        // level 1 是省级（可展开但不可选），level 2 是市级（可选且为叶子节点）
+        leaf: item.level === 2 // 市级为叶子节点，不再展开
+      }))
+      
+      resolve(nodes)
+    } catch (error) {
+      console.error('加载区域数据失败:', error)
+      resolve([])
+    }
+  }
+  
+  // 级联选择器变化时
+  const onCascaderChange = (value) => {
+    if (value && value.length > 0) {
+      // 可以选择任意层级进行筛选，取最后一级的ID
+      query.cityId = value[value.length - 1]
+    } else {
+      query.cityId = ''
+    }
+  }
 
   const houseList = ref([])
   const total = ref(null)
@@ -57,6 +99,8 @@
         query.cityId =
         query.communityName =
           ''
+      // 清空级联选择器
+      cascaderValue.value = []
       // 再请求
       getHouseList()
     }
@@ -127,18 +171,21 @@
           />
         </el-select>
       </el-form-item>
+      <div style="width: 100%; height: 0;"></div>
       <el-form-item label="所在城市">
-        <el-select
-          placeholder="请输入所在城市"
-          v-model="query.cityId"
-        >
-          <el-option
-            v-for="city in houseStore.cityList"
-            :key="city.id"
-            :value="city.id"
-            :label="city.fullName"
-          />
-        </el-select>
+        <el-cascader
+          v-model="cascaderValue"
+          :props="{ 
+            lazy: true,
+            lazyLoad: lazyLoad,
+            expandTrigger: 'hover',
+            emitPath: true,
+            checkStrictly: false
+          }"
+          @change="onCascaderChange"
+          placeholder="请选择城市"
+          clearable
+        />
       </el-form-item>
       <el-form-item label="所在小区">
         <el-input

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,7 +36,8 @@ export default defineConfig({
     proxy: {
       '/dev-api': {
         // 目前服务器地址
-        target: 'http://云服务器外网ip:80',
+        // target: 'http://云服务器外网ip:80', // 部署线上
+        target: 'http://127.0.0.1:10030', // 本地开发
         changeOrigin: true, // 改变请求头的origin源，到达目标服务器的值target的值，而不是前端的请求路径
 
         // 路径重写，如果不加rewrite，今后目标服务器收到的完整地址就是 http://127.0.0.1/dev-api/xxx,


### PR DESCRIPTION
- 替换原有的城市和区县下拉选择为级联选择器组件
- 实现区域数据懒加载功能，提高页面性能
- 添加级联选择器的路径跟踪和值绑定逻辑
- 更新房源表单提交时的城市区县信息获取方式
- 移除对全局城市列表的依赖，改用按需加载区域数据
- 优化搜索筛选功能中的城市选择交互体验